### PR TITLE
fix: Add missing man page

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,1 +1,2 @@
 install(FILES piTest.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+install(FILES ../lib/piControl/picontrol_ioctl.4 DESTINATION ${CMAKE_INSTALL_MANDIR}/man4)


### PR DESCRIPTION
As pointed out by
https://github.com/RevolutionPi/piControl/pull/93#issuecomment-1554105322, `picontrol_ioctl.4` was installed with `pitest` when using the Makefile, which is not the case anymore with CMake.
This patch installs the man page from the submodule as well.