### PR TITLE
fix: Force link of custom_target piControlReset

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ install(TARGETS ${TARGET} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 # then moving it to the install directory.
 # this needs to be done this way because the alternative way of doing
 # `install(CODE...` doesn't respect the installation prefix.
-ADD_CUSTOM_TARGET(piControlReset ALL
-	COMMAND ln -s ${TARGET} ${PROJECT_BINARY_DIR}/piControlReset)
+add_custom_target(piControlReset ALL
+	COMMAND ln -fs ${TARGET} ${PROJECT_BINARY_DIR}/piControlReset)
 install(FILES ${PROJECT_BINARY_DIR}/piControlReset
 	DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
The custom target `piControlReset` creates a symbolic link in the build directory. As custom targets are always considered out of date this symbolic link would be created again when building the second time. This will fail as the symbolic link already exists.
Calling `ln` with the flag `-f` forces the creation of the symbolic link even if one already exists.

This is useful for debianization especially as with debhelper-compat version 12 and below the variable `CMAKE_SKIP_INSTALL_ALL_DEPENDENCY` wasn't set, meaning a `make install` would try to rebuild the sources, making the build fail because of the existing but considered outdated symbolic link that wasn't overridden.
debhelper-compat version 13 sets this CMake variable which will make the install phase pass.

Useful links:
- https://manpages.debian.org/testing/debhelper/debhelper-compat-upgrade-checklist.7.en.html
- https://cmake.org/cmake/help/v3.25/variable/CMAKE_SKIP_INSTALL_ALL_DEPENDENCY.html

This PR is required to be merged for PR #4.