### PR TITLE
fix: End italics by reverting formatting

### DIFF
--- a/doc/piTest.1
+++ b/doc/piTest.1
@@ -66,7 +66,7 @@ Writes value \fIv\fP to the variable. It respects the length of variable as defi
 .br
 E.g. \fI-w Output_001,23\fP writes value 23 dec (= 17 hex) to variable \fIOutput_001\fP.
 .TP
-.B \-w \fIo,l,v\f
+.B \-w \fIo,l,v\fP
 Writes \fIl\fP bytes with value \fIv\fP (as dec) to offset \fIo\fP.  Length should
 be one of 1|2|4.  E.g. \fI-w 0,4,31224205\fP writes value 31224205 to the byte with offset 0 to 3.
 .TP


### PR DESCRIPTION
`\fI` activates italics for the following text, `\fP` restores the previous formatting. The latter was missing which lintian caught while building debian packages.