### PR TITLE
build: Don't depend on a C++ compiler for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.7)
 
-project(piTest)
+project(piTest LANGUAGES C)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
By default C *and* C++ are enabled as languages for CMake projects. Instead, only C should be enabled for a pure C project.