### PR TITLE
docs: Correct source code url

### DIFF
--- a/doc/piTest.1
+++ b/doc/piTest.1
@@ -111,4 +111,4 @@ The source code of this program is available at
 .IR https://github.com/RevolutionPi/revpi-pitest
 .br
 For more information on Revolution Pi visit
-.IR https://revolutionpi.kunbus.com
+.IR https://revolutionpi.com

--- a/doc/piTest.1
+++ b/doc/piTest.1
@@ -108,7 +108,7 @@ Reset control process.
 Show summary of options.
 .SH SEE ALSO
 The source code of this program is available at
-.IR https://github.com/RevolutionPi/piControl
+.IR https://github.com/RevolutionPi/revpi-pitest
 .br
 For more information on Revolution Pi visit
 .IR https://revolutionpi.kunbus.com


### PR DESCRIPTION
When this program was separated from the piControl repository the documentation wasn't updated to reflect that piTest now lives in a separate repository.